### PR TITLE
Make Log4jFilter check formatted message too

### DIFF
--- a/src/main/java/com/chaosthedude/consolefilter/filter/Log4jFilter.java
+++ b/src/main/java/com/chaosthedude/consolefilter/filter/Log4jFilter.java
@@ -15,7 +15,8 @@ public class Log4jFilter implements Filter {
 	@Override
 	public Filter.Result filter(LogEvent event) {
 		for (String s : ConfigHandler.getMessagesToFilter()) {
-			if (event.getMessage().toString().contains(s)) {
+			Message m = event.getMessage();
+			if (m.toString().contains(s) || m.getFormattedMessage().contains(s)) {
 				return Filter.Result.DENY;
 			}
 		}


### PR DESCRIPTION
This wasn't filtering certain exception messages because getMessage() was returning an empty string.

I added a check of getFormattedMessage() as well and it now seems to be able to filter everything.